### PR TITLE
Add two functions to return Laravel Collection instead of array

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ class StatusConst extends PhpConstant
     const COMPLETED = 'completed';
 }
 
+/*
+|--------------------------------------------------------------------------
+| Framework Agnostic Functions
+|--------------------------------------------------------------------------
+|
+| Simple functions not dependent to any framework and can be used in any PHP project.
+|
+*/
+
 // returns an array like this: ['pending', 'in_process', 'completed']
 StatusConst::all();
 
@@ -44,7 +53,24 @@ StatusConst::asString();
 // You can use any char you want as the glue for asString() function
 // returns a string like this: 'pending|in_process|completed'
 StatusConst::asString('|');
+
+/*
+|--------------------------------------------------------------------------
+| Laravel Specific Functions
+|--------------------------------------------------------------------------
+|
+| Functions to support [Laravel Collection](https://laravel.com/docs/collections) class.
+| Laravel Collection is a class that provides a fluent, convenient wrapper for working with arrays of data.
+|
+*/
+
+// returns a collection equivalent to: collect(['pending', 'in_process', 'completed'])
+StatusConst::collect();
+
+// returns a key-value collection equivalent to: collect(['pending' => 'Pending', 'in_process' => 'In Process', 'completed' => 'Completed'])
+StatusConst::collectOptions();
 ```
+
 ### Testing
 
 ```bash
@@ -77,4 +103,4 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 
 This package was generated using the [PHP Package Boilerplate](https://laravelpackageboilerplate.com)
 by [Beyond Code](http://beyondco.de/) 
-with some modifications inspired from [SPATIE Package Skeleton](https://github.com/spatie/package-skeleton-php).
+with some modifications inspired from [PHP Package Skeleton](https://github.com/spatie/package-skeleton-php) by [spatie](https://spatie.be/).

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.17",
+        "orchestra/testbench": "^6.18",
         "phpunit/phpunit": "^9.0",
         "vimeo/psalm": "^4.3"
     },
@@ -34,6 +35,16 @@
             "Kevinpurwito\\PhpConstant\\Tests\\": "tests"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Kevinpurwito\\PhpConstant\\PhpConstantServiceProvider"
+            ],
+            "aliases": [
+                "Kevinpurwito\\PhpConstant\\PhpConstantServiceFacade"
+            ]
+        }
+    },
     "scripts": {
         "format": "php-cs-fixer fix --allow-risky=yes",
         "psalm": "psalm",
@@ -45,6 +56,9 @@
         "test:coverage-clover": [
             "@putenv XDEBUG_MODE=coverage",
             "phpunit --color=always --coverage-clover coverage/clover.xml"
+        ],
+        "post-autoload-dump": [
+            "@php ./vendor/bin/testbench package:discover --ansi"
         ]
     },
     "config": {

--- a/src/PhpConstant.php
+++ b/src/PhpConstant.php
@@ -33,4 +33,16 @@ class PhpConstant
     {
         return implode($glue, static::all());
     }
+
+    /** @return \Illuminate\Support\Collection */
+    public static function collect()
+    {
+        return collect(static::all());
+    }
+
+    /** @return \Illuminate\Support\Collection */
+    public static function collectOptions()
+    {
+        return collect(static::options());
+    }
 }

--- a/src/PhpConstant.php
+++ b/src/PhpConstant.php
@@ -6,6 +6,14 @@ use ReflectionClass;
 
 class PhpConstant
 {
+    /*
+    |--------------------------------------------------------------------------
+    | Framework Agnostic Functions
+    |--------------------------------------------------------------------------
+    |
+    | Simple functions not dependent to any framework and can be used in any PHP project.
+    |
+    */
     public static function all(): array
     {
         $ref = new ReflectionClass(static::class);
@@ -33,6 +41,16 @@ class PhpConstant
     {
         return implode($glue, static::all());
     }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Laravel Specific Functions
+    |--------------------------------------------------------------------------
+    |
+    | Functions to support [Laravel Collection](https://laravel.com/docs/collections) class.
+    | Laravel Collection is a class that provides a fluent, convenient wrapper for working with arrays of data.
+    |
+    */
 
     /** @return \Illuminate\Support\Collection */
     public static function collect()

--- a/tests/PhpConstantTest.php
+++ b/tests/PhpConstantTest.php
@@ -55,8 +55,12 @@ class PhpConstantTest extends TestCase
     public function it_returns_constants_as_key_value_collection()
     {
         $statuses = StatusConst::collectOptions();
-        $this->assertTrue($statuses->contains(StatusConst::PENDING));
-        $this->assertTrue($statuses->contains(StatusConst::IN_PROCESS));
-        $this->assertTrue($statuses->contains(StatusConst::COMPLETED));
+        $this->assertArrayHasKey(StatusConst::PENDING, $statuses);
+        $this->assertArrayHasKey(StatusConst::IN_PROCESS, $statuses);
+        $this->assertArrayHasKey(StatusConst::COMPLETED, $statuses);
+
+        $this->assertTrue($statuses->contains(ucwords(str_replace('_', ' ', StatusConst::PENDING))));
+        $this->assertTrue($statuses->contains(ucwords(str_replace('_', ' ', StatusConst::IN_PROCESS))));
+        $this->assertTrue($statuses->contains(ucwords(str_replace('_', ' ', StatusConst::COMPLETED))));
     }
 }

--- a/tests/PhpConstantTest.php
+++ b/tests/PhpConstantTest.php
@@ -19,7 +19,6 @@ class PhpConstantTest extends TestCase
     public function it_returns_constants_as_array()
     {
         $statuses = StatusConst::all();
-        $this->assertTrue(is_array($statuses));
         $this->assertTrue(in_array(StatusConst::PENDING, $statuses));
         $this->assertTrue(in_array(StatusConst::IN_PROCESS, $statuses));
         $this->assertTrue(in_array(StatusConst::COMPLETED, $statuses));
@@ -29,7 +28,6 @@ class PhpConstantTest extends TestCase
     public function it_returns_constants_as_key_value_array()
     {
         $statuses = StatusConst::options();
-        $this->assertTrue(is_array($statuses));
         $this->assertTrue($statuses[StatusConst::PENDING] == ucwords(str_replace('_', ' ', StatusConst::PENDING)));
         $this->assertTrue($statuses[StatusConst::IN_PROCESS] == ucwords(str_replace('_', ' ', StatusConst::IN_PROCESS)));
         $this->assertTrue($statuses[StatusConst::COMPLETED] == ucwords(str_replace('_', ' ', StatusConst::COMPLETED)));
@@ -39,9 +37,26 @@ class PhpConstantTest extends TestCase
     public function it_returns_constants_as_string()
     {
         $statuses = StatusConst::asString();
-        $this->assertTrue(is_string($statuses));
         $this->assertTrue(strpos($statuses, StatusConst::PENDING) !== false);
         $this->assertTrue(strpos($statuses, StatusConst::IN_PROCESS) !== false);
         $this->assertTrue(strpos($statuses, StatusConst::COMPLETED) !== false);
+    }
+
+    /** @test */
+    public function it_returns_constants_as_collection()
+    {
+        $statuses = StatusConst::collect();
+        $this->assertTrue($statuses->contains(StatusConst::PENDING));
+        $this->assertTrue($statuses->contains(StatusConst::IN_PROCESS));
+        $this->assertTrue($statuses->contains(StatusConst::COMPLETED));
+    }
+
+    /** @test */
+    public function it_returns_constants_as_key_value_collection()
+    {
+        $statuses = StatusConst::collectOptions();
+        $this->assertTrue($statuses->contains(StatusConst::PENDING));
+        $this->assertTrue($statuses->contains(StatusConst::IN_PROCESS));
+        $this->assertTrue($statuses->contains(StatusConst::COMPLETED));
     }
 }


### PR DESCRIPTION
## Added
2 Additional Functions to support [Laravel Collection](https://laravel.com/docs/collections) class.
Laravel Collection is a class that provides a fluent, convenient wrapper for working with arrays of data.

```php
use KevinPurwito\PhpConstant\PhpConstant;

// Class Extends PhpConstant to use its functions
class StatusConst extends PhpConstant
{
    const PENDING = 'pending';
    const IN_PROCESS = 'in_process';
    const COMPLETED = 'completed';
}

// returns a collection equivalent to: collect(['pending', 'in_process', 'completed'])
StatusConst::collect();

// returns a key-value collection equivalent to: collect(['pending' => 'Pending', 'in_process' => 'In Process', 'completed' => 'Completed'])
StatusConst::collectOptions();
```